### PR TITLE
Pimoroni pHAT support

### DIFF
--- a/display.py
+++ b/display.py
@@ -12,7 +12,6 @@ except NotImplementedError as exc:
     print(f"Will only support running with -o: {exc}")
 
 from adafruit_epd.ssd1680 import Adafruit_SSD1680
-from inky.auto import auto
 
 
 # pylint: disable=too-few-public-methods
@@ -58,67 +57,35 @@ class AdafruitDisplay(Display):
         logger.debug("display done")
 
 
-# pylint: disable=too-few-public-methods
-class InkyDisplay(Display):
-    """
-    class to wrap the Pimoroni pHAT eInk display
-    """
-
-    def update(self, image):
-        """
-        Display image.
-        :param image: image to display
-        :return:
-        """
-        logger = logging.getLogger(__name__)
-
-        logger.debug("display in progress")
-        self.display.set_image(image)
-        self.display.show()
-        logger.debug("display done")
-
-
 def get_e_ink_display():
     """
     :return: Display instance
     """
     logger = logging.getLogger(__name__)
 
-    try:
-        # Create the SPI device and pins we will need.
-        spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
-        ecs = digitalio.DigitalInOut(board.CE0)
-        # pylint: disable=invalid-name
-        dc = digitalio.DigitalInOut(board.D22)
-        rst = digitalio.DigitalInOut(board.D27)
-        busy = digitalio.DigitalInOut(board.D17)
+    # Create the SPI device and pins we will need.
+    spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
+    ecs = digitalio.DigitalInOut(board.CE0)
+    # pylint: disable=invalid-name
+    dc = digitalio.DigitalInOut(board.D22)
+    rst = digitalio.DigitalInOut(board.D27)
+    busy = digitalio.DigitalInOut(board.D17)
 
-        # 2.13" HD Tri-color or mono display
-        display_height = 122
-        display_width = 250
+    # 2.13" HD Tri-color or mono display
+    display_height = 122
+    display_width = 250
 
-        display = Adafruit_SSD1680(
-            display_height,
-            display_width,
-            spi,
-            cs_pin=ecs,
-            dc_pin=dc,
-            sramcs_pin=None,
-            rst_pin=rst,
-            busy_pin=busy,
-        )
+    display = Adafruit_SSD1680(
+        display_height,
+        display_width,
+        spi,
+        cs_pin=ecs,
+        dc_pin=dc,
+        sramcs_pin=None,
+        rst_pin=rst,
+        busy_pin=busy,
+    )
 
-        display.rotation = 1
-        logger.info("Detected Adafruit SSD1680 display")
-        return AdafruitDisplay(display, display_width, display_height)
-    except Exception:  # pylint: disable=broad-exception-caught
-        pass
-
-    # Fall back to Pimoroni pHAT.
-    try:
-        display = auto()
-        logger.info("Detected Pimoroni pHAT")
-        return InkyDisplay(display, display.resolution[0], display.resolution[1])
-    except RuntimeError as e:
-        logger.error(f"cannot initialize inky pHAT: {e}")
-        return None
+    display.rotation = 1
+    logger.info("Detected Adafruit SSD1680 display")
+    return AdafruitDisplay(display, display_width, display_height)

--- a/display.py
+++ b/display.py
@@ -119,5 +119,6 @@ def get_e_ink_display():
         display = auto()
         logger.info("Detected Pimoroni pHAT")
         return InkyDisplay(display, display.resolution[0], display.resolution[1])
-    except Exception:
+    except RuntimeError as e:
+        logger.error("cannot initialize inky pHAT: {e}")
         return None

--- a/display.py
+++ b/display.py
@@ -111,7 +111,7 @@ def get_e_ink_display():
         display.rotation = 1
         logger.info("Detected Adafruit SSD1680 display")
         return AdafruitDisplay(display, display_width, display_height)
-    except Exception:
+    except Exception:  # pylint: disable=broad-exception-caught
         pass
 
     # Fall back to Pimoroni pHAT.

--- a/display.py
+++ b/display.py
@@ -120,5 +120,5 @@ def get_e_ink_display():
         logger.info("Detected Pimoroni pHAT")
         return InkyDisplay(display, display.resolution[0], display.resolution[1])
     except RuntimeError as e:
-        logger.error("cannot initialize inky pHAT: {e}")
+        logger.error(f"cannot initialize inky pHAT: {e}")
         return None

--- a/display.py
+++ b/display.py
@@ -1,5 +1,5 @@
 """
-display class
+display classes
 """
 
 import logging
@@ -11,15 +11,8 @@ try:
 except NotImplementedError as exc:
     print(f"Will only support running with -o: {exc}")
 
-try:
-    from adafruit_epd.ssd1680 import Adafruit_SSD1680
-except ImportError:
-    pass
-
-try:
-    from inky.auto import auto
-except ImportError:
-    pass
+from adafruit_epd.ssd1680 import Adafruit_SSD1680
+from inky.auto import auto
 
 
 # pylint: disable=too-few-public-methods

--- a/metrics_drawer.py
+++ b/metrics_drawer.py
@@ -1,0 +1,262 @@
+"""
+MetricsDrawer class
+
+Not dependent on the output type.
+"""
+
+import logging
+from datetime import datetime
+
+from PIL import Image, ImageDraw, ImageFont
+from prometheus_api_client import (
+    MetricsList,
+    PrometheusApiClientException,
+    PrometheusConnect,
+)
+
+
+# pylint: disable=too-many-instance-attributes
+class MetricsDrawer:
+    """
+    Class to wrap fetching and drawing of the metrics.
+    """
+
+    # First define some color constants
+    WHITE = (0xFF, 0xFF, 0xFF)
+    BLACK = (0x00, 0x00, 0x00)
+
+    # Next define some constants to allow easy resizing of shapes and colors
+    BACKGROUND_COLOR = WHITE
+    FOREGROUND_COLOR = WHITE
+    TEXT_COLOR = BLACK
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        url,
+        display_width,
+        display_height,
+        medium_font_path,
+        large_font_path,
+        temp_sensor_name,
+    ):
+        """
+        :param url: URL to retrieve the metrics from
+        :param display_height: display width in pixels
+        :param display_width: display height in pixels
+        :param large_font_path: path to font used for large letters
+        :param medium_font_path: path to font used for medium letters
+        :param temp_sensor_name: temperature sensor name
+        """
+        self.url = url
+        self.display_width = display_width
+        self.display_height = display_height
+
+        self.small_font = ImageFont.truetype(large_font_path, 12)
+        self.medium_font = ImageFont.truetype(medium_font_path, 24)
+        self.large_font = ImageFont.truetype(large_font_path, 64)
+
+        self.temp_sensor_name = temp_sensor_name
+
+        self.image = Image.new("RGB", (self.display_width, self.display_height))
+
+        # Get drawing object to draw on image.
+        self.draw = ImageDraw.Draw(self.image)
+
+        self.prometheus_connect = PrometheusConnect(url=url)
+
+    def extract_metric_from_data(self, data):
+        """
+        Given JSON string, extract metric value and return as string
+        :param data:
+        :return:
+        """
+        temp_list = MetricsList(data)
+        metric = temp_list[0]
+        return str(metric.metric_values.y[0])
+
+    def get_metrics(self):
+        """
+        Retrieve metrics from given URL and return them. If a metric cannot be retrieved,
+        None is used instead.
+        :return: tuple of temperature, CO2, atmospheric pressure (as strings)
+        """
+        temp = None
+        co2 = None
+        pressure = None
+
+        logger = logging.getLogger(__name__)
+
+        try:
+            temp_data = self.prometheus_connect.custom_query(
+                # pylint: disable=consider-using-f-string
+                "last_over_time(temperature{sensor='%s'}[30m])"
+                % self.temp_sensor_name
+            )
+            temp = self.extract_metric_from_data(temp_data)
+        except (PrometheusApiClientException, IndexError) as req_exc:
+            logger.error(f"cannot get data for temperature from {self.url}: {req_exc}")
+
+        try:
+            co2_data = self.prometheus_connect.get_current_metric_value(
+                metric_name="co2_ppm"
+            )
+            co2 = self.extract_metric_from_data(co2_data)
+        except (PrometheusApiClientException, IndexError) as req_exc:
+            logger.error(f"cannot get data for CO2 from {self.url}: {req_exc}")
+
+        try:
+            pressure_data = self.prometheus_connect.get_current_metric_value(
+                metric_name="pressure_hpa{name='sea'}"
+            )
+            pressure = self.extract_metric_from_data(pressure_data)
+        except (PrometheusApiClientException, IndexError) as req_exc:
+            logger.error(
+                f"cannot get data for barometric pressure from {self.url}: {req_exc}"
+            )
+
+        return temp, co2, pressure
+
+    def draw_image(self):
+        """
+        Refresh the display with weather metrics retrieved from the URL
+        :return PIL image instance
+        """
+
+        temp, co2, pressure = self.get_metrics()
+
+        # Draw a filled box as the background
+        self.draw.rectangle(
+            (0, 0, self.display_width - 1, self.display_height - 1),
+            fill=MetricsDrawer.BACKGROUND_COLOR,
+        )
+
+        self.draw_date_time()
+
+        text_height = self.draw_outside_temperature(temp)
+        current_height = self.draw_co2(co2, text_height)
+        self.draw_pressure(current_height, pressure)
+
+        return self.image
+
+    def draw_pressure(self, current_height, pressure):
+        """
+        :param current_height:
+        :param pressure:
+        :return:
+        """
+        logger = logging.getLogger(__name__)
+
+        # Draw atmospheric pressure level.
+        if pressure:
+            pressure = int(float(pressure))
+            text = f"Pressure: {pressure} hPa"
+        else:
+            text = "Pressure: N/A"
+        logger.debug(text)
+        coordinates = (0, current_height)  # use previous text height
+        logger.debug(f"coordinates = {coordinates}")
+        self.draw.text(
+            coordinates,
+            text,
+            font=self.medium_font,
+            fill=MetricsDrawer.TEXT_COLOR,
+        )
+
+    def draw_co2(self, co2, text_height):
+        """
+        :param co2:
+        :param text_height:
+        :return: current text height
+        """
+        logger = logging.getLogger(__name__)
+
+        # Draw CO2 level.
+        co_text = "CO₂"
+        if co2:
+            co2 = int(float(co2))
+            text = f"{co_text} : {co2} ppm"
+        else:
+            text = f"{co_text} : N/A"
+        coordinates = (0, text_height + 10)  # use previous text height
+        current_height = text_height + 10
+        if hasattr(self.medium_font, "getsize"):
+            (_, text_height) = self.medium_font.getsize(text)
+        else:
+            text_height = self.medium_font.getbbox(text)[3]
+        current_height = current_height + text_height
+        logger.debug(f"'{text}' coordinates = {coordinates}")
+        self.draw.text(
+            coordinates,
+            text,
+            font=self.medium_font,
+            fill=MetricsDrawer.TEXT_COLOR,
+        )
+
+        return current_height
+
+    def draw_outside_temperature(self, temp):
+        """
+        :param temp: temperature value
+        :return: current text height
+        """
+        logger = logging.getLogger(__name__)
+
+        # Draw outside temperature.
+        if temp:
+            outside_temp = int(float(temp))
+            text = f"{outside_temp}°C"
+        else:
+            text = "N/A"
+        logger.debug(text)
+        if hasattr(self.medium_font, "getsize"):
+            (text_width, text_height) = self.large_font.getsize(text)
+        else:
+            (text_width, text_height) = self.large_font.getbbox(text)[2:4]
+        logger.debug(f"text width={text_width}, height={text_height}")
+        logger.debug(
+            f"display width={self.display_width}, height={self.display_height}"
+        )
+        coordinates = (0, 0)
+        logger.debug(f"coordinates = {coordinates}")
+        self.draw.text(
+            coordinates,
+            text,
+            font=self.large_font,
+            fill=MetricsDrawer.TEXT_COLOR,
+        )
+        return text_height
+
+    def draw_date_time(self):
+        """
+        Draw date and time in the top right corner.
+        """
+        logger = logging.getLogger(__name__)
+
+        # Draw time.
+        now = datetime.now()
+        text = now.strftime(f"{now.hour}:%M")
+        logger.debug(text)
+        if hasattr(self.medium_font, "getsize"):
+            (text_width, text_height) = self.medium_font.getsize(text)
+        else:
+            (text_width, text_height) = self.medium_font.getbbox(text)[2:4]
+        coordinates = (self.display_width - text_width - 10, 0)
+        logger.debug(f"coordinates = {coordinates}")
+        self.draw.text(
+            coordinates,
+            text,
+            font=self.medium_font,
+            fill=MetricsDrawer.TEXT_COLOR,
+        )
+        # Draw date underneath the time.
+        text = now.strftime(f"{now.day}.{now.month}.")
+        logger.debug(text)
+        coordinates = (self.display_width - text_width - 10, text_height + 5)
+        logger.debug(f"coordinates = {coordinates}")
+        self.draw.text(
+            coordinates,
+            text,
+            font=self.medium_font,
+            fill=MetricsDrawer.TEXT_COLOR,
+        )

--- a/metrics_drawer.py
+++ b/metrics_drawer.py
@@ -30,7 +30,7 @@ class MetricsDrawer:
     FOREGROUND_COLOR = WHITE
     TEXT_COLOR = BLACK
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(
         self,
         url,

--- a/report.py
+++ b/report.py
@@ -9,59 +9,9 @@ import logging
 import sys
 import time
 
-try:
-    import board
-    import busio
-    import digitalio
-except NotImplementedError as exc:
-    print(f"Will only support running with -o: {exc}")
-from adafruit_epd.ssd1680 import Adafruit_SSD1680
-
-from display import Display
+from display import get_e_ink_display
 from logutil import LogLevelAction
-
-
-def get_e_ink_display(height, width):
-    """
-    :return: eInk display instance
-    """
-    # Create the SPI device and pins we will need.
-    spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
-    ecs = digitalio.DigitalInOut(board.CE0)
-    # pylint: disable=invalid-name
-    dc = digitalio.DigitalInOut(board.D22)
-    rst = digitalio.DigitalInOut(board.D27)
-    busy = digitalio.DigitalInOut(board.D17)
-
-    display = Adafruit_SSD1680(
-        height,
-        width,
-        spi,
-        cs_pin=ecs,
-        dc_pin=dc,
-        sramcs_pin=None,
-        rst_pin=rst,
-        busy_pin=busy,
-    )
-
-    display.rotation = 1
-
-    return display
-
-
-def update_e_ink_display(display, image):
-    """
-    Display image.
-    :param display:
-    :param image:
-    :return:
-    """
-    logger = logging.getLogger(__name__)
-
-    logger.debug("display in progress")
-    display.image(image)
-    display.display()
-    logger.debug("display done")
+from metrics_drawer import MetricsDrawer
 
 
 def parse_args():
@@ -133,7 +83,7 @@ def main():
     display_height = 122
     display_width = 250
 
-    display = Display(
+    drawer = MetricsDrawer(
         args.url,
         display_width,
         display_height,
@@ -142,12 +92,15 @@ def main():
         args.temp_sensor_name,
     )
     if args.output:
-        image = display.draw_image()
+        image = drawer.draw_image()
         image.save(args.output)
         return
 
-    e_display = get_e_ink_display(display_height, display_width)
-    display = Display(
+    e_display = get_e_ink_display()
+    if e_display is None:
+        logger.error("No display detected")
+        sys.exit(1)
+    drawer = MetricsDrawer(
         args.url,
         e_display.width,
         e_display.height,
@@ -156,8 +109,8 @@ def main():
         args.temp_sensor_name,
     )
     while True:
-        image = display.draw_image()
-        update_e_ink_display(e_display, image)
+        image = drawer.draw_image()
+        e_display.update(image)
         time.sleep(args.timeout)
 
 

--- a/report.py
+++ b/report.py
@@ -96,10 +96,12 @@ def main():
         image.save(args.output)
         return
 
+    logger.debug("Getting display")
     e_display = get_e_ink_display()
     if e_display is None:
         logger.error("No display detected")
         sys.exit(1)
+    logger.debug(f"Got e-display: {e_display.display}")
     drawer = MetricsDrawer(
         args.url,
         e_display.width,
@@ -109,6 +111,7 @@ def main():
         args.temp_sensor_name,
     )
     while True:
+        logger.debug("Drawing image")
         image = drawer.draw_image()
         e_display.update(image)
         time.sleep(args.timeout)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pillow
 requests
 wheel
 prometheus-api-client
-inky

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pillow
 requests
 wheel
 prometheus-api-client
+inky


### PR DESCRIPTION
After trying the original Adafruit EDP library first, I realized it actually works just fine with Pimoroni inky pHAT. The pHAT has actually the same resolution as the original Adafruit display. So, I decided to keep the Adafruit library even though I already performed the refactoring to support both. There are actually more reasons to prefer the Adafruit library:

The `inky` library requires more setup than the Adafruit EDP library. It requires both I2C and SPI setup.

Further, after adding `dtoverlay=spi0-0cs` to `/boot/config` (the https://github.com/pimoroni/inky README says `/boot/firmware/config.txt` however that does not exist on Raspbian GNU/Linux 11 (bullseye) and has no effect even if created) it still complains, this time with different error message as before:
```
Woah there, some pins we need are in use!
  ⚠️   Chip Select: (line 8, SPI_CE0_N) currently claimed by spi-bcm2835
```
and what is more, it exits the whole program rather than throwing an exception.